### PR TITLE
add support for chakracore-nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ $ nodejs-nightly-builder [--type <nightly|next-nightly>] --ref <git head ref> --
   - ***"githubScheme"*** (optional, defaults to "https://github.com/"): the scheme for accessing the GitHub repository, including host and other components up to the "org/repo"
   - ***"githubAuthUser"***: the user for which the GitHub API is being accessed by
   - ***"githubAuthToken"***: the authentication token for accessing the API for the given user (e.g. obtained with https://github.com/rvagg/ghauth)
-  - ***"releaseUrlBase"*** (optional, defaults to "https://nodejs.org/download/"): the release URL base passed to `--configure` when building Node.js, this is given to Jenkins and passed down in to the builders, the `type` is appended to the end
   - ***"jenkinsToken"***: the token entered in the Jenkins job for building distributables, required to authenticate API triggered access
   - ***"jenkinsJobUrl"***: URL of the job being accessed, as you would as a normal user, e.g. "https://ci.nodejs.org/job/node-release"
   - ***"jenkinsCrumbUrl"***: the Jenkins API endpoint for obtaining a crumb for bypassing XSS checks during API access, e.g. "https://ci.nodejs.org/crumbIssuer/api/json"
 
 The GitHub API is used to check HEAD commits which is why an authentication token is required.
 
-When run, `nodejs-nightly-builder` will first check whether a build is required. It does this by checking the file at `{releaseUrlBase}{type}/index.json`, where `{releaseUrlBase}` comes from the config file and `type` is provided on the commandline, e.g. `https://nodejs.org/download/nightly/index.json`. Nightly builds contain a commit sha that can be decoded from their version string. The HEAD commit is also pulled from GitHub for the `ref` (branch) provided on the commandline. If the latest build does not match the HEAD commit, a new nightly build is required. Nightly builds are triggered with Jenkins.
+When run, `nodejs-nightly-builder` will first check whether a build is required. It does this by checking the file at `https://nodejs.org/download/{type}/index.json`, where `type` is provided on the commandline, e.g. `https://nodejs.org/download/nightly/index.json`. Nightly builds contain a commit sha that can be decoded from their version string. The HEAD commit is also pulled from GitHub for the `ref` (branch) provided on the commandline. If the latest build does not match the HEAD commit, a new nightly build is required. Nightly builds are triggered with Jenkins.
 
 -----------------------------------
 

--- a/list-builds.js
+++ b/list-builds.js
@@ -6,7 +6,7 @@ const indexUrl = 'https://nodejs.org/download/{type}/index.json'
 
 
 function listBuilds (type, config, callback) {
-  let url = indexUrl.replace(/\{type\}/, type)
+  let url = indexUrl.replace(/\{type\}/, `${config.urlTypePrefix || ''}${type}`)
 
   function onGet (err, data) {
     if (err)

--- a/list-builds.js
+++ b/list-builds.js
@@ -2,13 +2,11 @@
 
 const jsonist = require('jsonist')
 
-const indexUrl = '{releaseUrlBase}{type}/index.json'
+const indexUrl = 'https://nodejs.org/download/{type}/index.json'
 
 
 function listBuilds (type, config, callback) {
-  let url = indexUrl
-              .replace(/\{type\}/, type)
-              .replace(/\{releaseUrlBase\}/, config.releaseUrlBase)
+  let url = indexUrl.replace(/\{type\}/, type)
 
   function onGet (err, data) {
     if (err)
@@ -18,7 +16,7 @@ function listBuilds (type, config, callback) {
       return callback(new Error(`no builds for "${type}"`))
 
     data = data.map(function (d) {
-      let m      = d.version.match(/nightly(20\d\d)(\d\d)(\d\d)([0-9a-f]{7,})/)
+      let m      = d.version.match(/(?:nightly|v8-canary)(20\d\d)(\d\d)(\d\d)([0-9a-f]{7,})/)
         , date   = new Date(m && `${m[1]}-${m[2]}-${m[3]}` || d.date)
         , commit = m && m[4]
 
@@ -41,7 +39,7 @@ function listBuilds (type, config, callback) {
 module.exports = listBuilds
 
 if (require.main == module) {
-  listBuilds('nightly', function (err, data) {
+  listBuilds(process.argv[2] || 'nightly', function (err, data) {
     if (err)
       throw err
 

--- a/nightly-builder.js
+++ b/nightly-builder.js
@@ -17,6 +17,7 @@ const argv          = require('minimist')(process.argv.slice(2))
           githubOrg       : 'nodejs'
         , githubRepo      : 'node'
         , githubScheme    : 'https://github.com/'
+        , urlTypePrefix   : ''
       }
 
 if (typeof argv.type != 'string')
@@ -35,6 +36,7 @@ if (!/^(nightly|v8-canary)$/.test(argv.type)
     || typeof config.githubRepo      != 'string'
     || typeof config.githubOrg       != 'string'
     || typeof config.githubScheme    != 'string'
+    || typeof config.urlTypePrefix   != 'string'
   ) {
 
   console.error('Invalid arguments or config')

--- a/nightly-builder.js
+++ b/nightly-builder.js
@@ -17,7 +17,6 @@ const argv          = require('minimist')(process.argv.slice(2))
           githubOrg       : 'nodejs'
         , githubRepo      : 'node'
         , githubScheme    : 'https://github.com/'
-        , releaseUrlBase  : 'https://nodejs.org/download/'
       }
 
 if (typeof argv.type != 'string')
@@ -26,7 +25,7 @@ if (typeof argv.type != 'string')
 let config = argv.config && require(argv.config)
 config = xtend(defaultConfig, config)
 
-if (!/^(nightly|next-nightly)$/.test(argv.type)
+if (!/^(nightly|v8-canary)$/.test(argv.type)
     || typeof argv.ref != 'string'
     || typeof config.jenkinsToken    != 'string'
     || typeof config.jenkinsJobUrl   != 'string'
@@ -36,11 +35,10 @@ if (!/^(nightly|next-nightly)$/.test(argv.type)
     || typeof config.githubRepo      != 'string'
     || typeof config.githubOrg       != 'string'
     || typeof config.githubScheme    != 'string'
-    || typeof config.releaseUrlBase  != 'string'
   ) {
 
   console.error('Invalid arguments or config')
-  console.error('Usage: nodejs-nightly-builder [--type <nightly|next-nightly>] --ref <git head ref> --config <config file> [--force]')
+  console.error('Usage: nodejs-nightly-builder [--type <nightly|v8-canary>] --ref <git head ref> --config <config file> [--force]')
   return process.exit(1)
 }
 

--- a/package.json
+++ b/package.json
@@ -14,18 +14,19 @@
   },
   "dependencies": {
     "after": "~0.8.2",
-    "bl": "~1.1.2",
+    "bl": "~1.2.1",
     "ghrepos": "~2.0.0",
-    "hyperquest": "~2.1.0",
-    "jsonist": "~1.3.0",
+    "hyperquest": "~2.1.2",
+    "jsonist": "~2.1.0",
+    "level": "~1.7.0",
     "minimist": "~1.2.0",
-    "strftime": "~0.9.2",
+    "strftime": "~0.10.0",
     "xtend": "~4.0.1"
   },
   "devDependencies": {
     "application-config": "~1.0.1",
     "ghauth": "~3.2.1",
-    "tape": "~4.6.2"
+    "tape": "~4.6.3"
   },
   "bin": {
     "nodejs-nightly-builder": "./nightly-builder.js"

--- a/test.js
+++ b/test.js
@@ -1,8 +1,9 @@
 "use strict"
 
 const test         = require('tape')
+    , after        = require('after')
     , latestCommit = require('./latest-commit')
-    , listBuilds  = require('./list-builds')
+    , listBuilds   = require('./list-builds')
     , ghauth       = require('ghauth')
     , appCfg       = require('application-config')
     , authOptions  = {
@@ -24,7 +25,6 @@ test('list-builds', function (t) {
   t.plan(7)
   let other = null
 
-
   function verify () {
     return function (err, data) {
       t.error(err, 'no error')
@@ -39,7 +39,36 @@ test('list-builds', function (t) {
     }
   }
 
-  listBuilds('nightly', verify())
+  listBuilds('nightly', {}, verify())
+})
+
+
+test('list-builds chakracore-nightly', function (t) {
+  t.plan(6)
+  let done = after(2, verify())
+    , data1
+    , data2
+
+  function verify () {
+    return function (err) {
+      t.error(err, 'no error')
+      t.ok(Array.isArray(data1), ' data1 is array')
+      t.ok(data1.length > 1, 'data1 has data')
+      t.ok(Array.isArray(data2), 'data2 is array')
+      t.ok(data2.length > 1, 'data2 has data')
+      t.notDeepEqual(data1, data2, 'different data with and without urlTypePrefix')
+    }
+  }
+
+  listBuilds('nightly', {}, function (err, data) {
+    data1 = data
+    done(err)
+  })
+
+  listBuilds('nightly', { urlTypePrefix: 'chakracore-' }, function (err, data) {
+    data2 = data
+    done(err)
+  })
 })
 
 
@@ -62,7 +91,7 @@ test('list-builds v8-canary', function (t) {
     }
   }
 
-  listBuilds('v8-canary', verify())
+  listBuilds('v8-canary', {}, verify())
 })
 
 

--- a/test.js
+++ b/test.js
@@ -35,11 +35,34 @@ test('list-builds', function (t) {
       t.ok(data[0].date < new Date(), `date (${data[0].date.toISOString()}) looks correct`)
       t.ok(data[0].commit && data[0].commit.length >= 10, `commit (${data[0].commit}) looks right`)
       t.notEqual(data[0].commit, other, 'commit not the same as other type of commit')
-      other = data[0].commit // who's gonna be first??      
+      other = data[0].commit // who's gonna be first??
     }
   }
 
-  listBuilds('nightly', { releaseUrlBase: 'https://nodejs.org/download/' }, verify())
+  listBuilds('nightly', verify())
+})
+
+
+test('list-builds v8-canary', function (t) {
+  t.plan(7)
+  let other = null
+
+
+  function verify () {
+    return function (err, data) {
+      t.error(err, 'no error')
+      t.ok(Array.isArray(data), 'is array')
+      t.ok(data.length >= 1, 'has data')
+      let m = data[0].version && data[0].version.match(/v\d+\.\d+\.\d+-v8-canary20\d{6}\w{10,}/)
+      t.ok(m, `version (${data[0].version}) looks correct`)
+      t.ok(data[0].date < new Date(), `date (${data[0].date.toISOString()}) looks correct`)
+      t.ok(data[0].commit && data[0].commit.length >= 10, `commit (${data[0].commit}) looks right`)
+      t.notEqual(data[0].commit, other, 'commit not the same as other type of commit')
+      other = data[0].commit // who's gonna be first??
+    }
+  }
+
+  listBuilds('v8-canary', verify())
 })
 
 
@@ -66,6 +89,36 @@ test('latest-commit', function (t) {
     latestCommit('nightly', 'heads/v5.x', {
         githubOrg       : 'nodejs'
       , githubRepo      : 'node'
+      , githubAuthUser  : config.user
+      , githubAuthToken : config.token
+    }, verify())
+  })
+})
+
+
+test('latest-commit v8-canary', function (t) {
+  t.plan(4)
+  let other = null
+
+  appCfg(authOptions.configName).read(function (err, config) {
+    if (err) {
+      console.error('You need GitHub authentication credentials saved first, run `node test.js auth` to set this up')
+      return process.exit(1)
+    }
+
+    function verify () {
+      return function (err, sha) {
+        t.error(err, 'no error')
+        t.equal(typeof sha, 'string', 'got sha')
+        t.equal(sha.length, 40, `sha looks good (${sha})`)
+        t.notEqual(sha, other, 'sha not the same as other type of sha')
+        other = sha // who's gonna be first??
+      }
+    }
+
+    latestCommit('v8-canary', 'heads/canary', {
+        githubOrg       : 'nodejs'
+      , githubRepo      : 'node-v8'
       , githubAuthUser  : config.user
       , githubAuthToken : config.token
     }, verify())

--- a/trigger-build.js
+++ b/trigger-build.js
@@ -30,10 +30,6 @@ function triggerBuild(options, callback) {
                 , value : options.type
               }
             , {
-                  name  : 'release_urlbase'
-                , value : `${options.releaseUrlBase}${options.type}/`
-              }
-            , {
                   name  : 'rc'
                 , value : '0'
               }


### PR DESCRIPTION
Node-ChakraCore produces builds of type `nightly` and uploads them to a directory named `chakracore-nightly`. This adds support for a prefix that can be set to `chakracore-`.

This PR includes the commit under review in https://github.com/nodejs/nodejs-nightly-builder/pull/1 by @rvagg , so this can be easily rebased after that PR lands.

cc @nodejs/build 